### PR TITLE
hld: fix bug

### DIFF
--- a/graph/hld.cpp
+++ b/graph/hld.cpp
@@ -22,7 +22,7 @@ void dfs_hld(int v = 0, int from = -1) {
 
 void init(int root = 0) {
 	int n = sz(adj);
-	sz.assign(n, 1), nxt.assign(n, 0), par.assign(n, -1);
+	sz.assign(n, 1), nxt.assign(n, root), par.assign(n, -1);
 	in.resize(n), out.resize(n);
 	counter = 0;
 	dfs_sz(root);


### PR DESCRIPTION
Nach Initialisierung mit root!=0 war nxt[root]=0!=root. Dadurch gab es (mindestens, aber nicht nur) diesen Fehler: Beim Aufruf von for_intervals mit u=v=root wurde f mit
max(in[root], in[nxt[root]]
=max(0, in[0])
=in[0],
einer quasi beliebigen Zahl, aufgerufen