### PR TITLE
shorter rerooting

### DIFF
--- a/content/graph/reroot.cpp
+++ b/content/graph/reroot.cpp
@@ -3,14 +3,14 @@
 
 // To remove weights, remove every "w" and "W" and fix errors
 struct Reroot {
-  using D = /todo/; // dp value
-  using A = /todo/ (often D); // value from a vertex's child(ren)
-                            // (A,agg,e) commutative monoid
+  using D = /*todo*/; // dp value
+  using A = /*todo(often D)*/; //value from a vertex's child(ren)
+                               //(A,agg,e) commutative monoid
 
-  A e = /todo/;
-  A fromChild(int v, int c, auto w, D dp_c) { /todo/ }
-  static A agg(A a, A b) { /todo/ }
-  D fin(int v, A chilsAgg) { /todo/ }
+  A e = /*todo*/;
+  A fromChild(int v, int c, auto w, D dp_c) { /*todo*/ }
+  static A agg(A a, A b) { /*todo*/ }
+  D fin(int v, A chilsAgg) { /*todo*/ }
 
   vector<D> dp;
 

--- a/content/graph/reroot.cpp
+++ b/content/graph/reroot.cpp
@@ -4,7 +4,7 @@ vector<vector<pair<int, W>>> adj;
 struct Reroot {
 	using T = ll; // dp type
 
-	T E = 0; // neutral element
+	static constexpr T E = 0; // neutral element
 	T takeChild(int v, int c, W w, T x) {} // move child along edge
 	static T comb(T x, T y) {}
 	T fin(int v, T x) {} // add v to own dp value x

--- a/content/graph/reroot.cpp
+++ b/content/graph/reroot.cpp
@@ -29,8 +29,8 @@ struct Reroot {
       ps.push_back(fromChild(v, c, w, dp[c]));
     }
     auto ss = ps;
-    exclusive_scan(ps.begin(), ps.end(), ps.begin(), e, agg);
-    exclusive_scan(ss.rbegin(),ss.rend(),ss.rbegin(),e, agg);
+    exclusive_scan(be(ps), ps.begin(), e, agg);
+    exclusive_scan(ss.rbegin(), ss.rend(), ss.rbegin(), e, agg);
     int i = 0;
     for (auto [c, w] : g[v]) {
       ++i;

--- a/content/graph/reroot.cpp
+++ b/content/graph/reroot.cpp
@@ -35,7 +35,7 @@ struct Reroot {
       dp[v] = fin(v, agg(ss[i], ps[i]));
       dfs1(c, v, g);
     }
-    dp[v] = fin(v, s[0]);
+    dp[v] = fin(v, ss[0]);
   }
 
   auto solve(auto g) {

--- a/content/graph/reroot.cpp
+++ b/content/graph/reroot.cpp
@@ -1,62 +1,47 @@
-// Usual Tree DP can be broken down in 4 steps:
-// - Initialize dp[v] = identity
-// - Iterate over all children w and take a value for w 
-//	 by looking at dp[w] and possibly the edge label of v -> w
-// - combine the values of those children
-//	 usually this operation should be commutative and associative
-// - finalize the dp[v] after iterating over all children
+// input: undirected (un)weighted tree as
+//        adjacency list containing pair<neighbour,weight>s
+//        (To remove weights, remove every "w" and fix errors)
+// output[r] = dp[r], where dp[v] :=
+//  fin(Sum_{child c of v, regarding root r} from_child( dp[c] ))
 struct Reroot {
-	using T = ll;
+  using D = todo; // dp value
+  using A = todo (often D); // value from a vertex's child(ren)
+                            // (A,agg,e) commutative monoid
 
-	// identity element
-	T E() {}
-	// x: dp value of child
-	// e: index of edge going to child
-	T takeChild(T x, int e) {}
-	T comb(T x, T y) {}
-	// called after combining all dp values of children
-	T fin(T x, int v) {}
+  A e = todo;
+  A from_child(z v, z c, auto w, D dp_c) { todo }
+  static A agg(A a, A b) { todo }
+  D fin(z v, A chils_agg) { todo }
 
-	vector<vector<pair<int, int>>> g;
-	vector<int> ord, pae;
-	vector<T> dp;
+  vector<D> dp;
 
-	T dfs(int v) {
-		ord.push_back(v);
-		for (auto [w, e] : g[v]) {
-			g[w].erase(find(all(g[w]), pair(v, e^1)));
-			pae[w] = e^1;
-			dp[v] = comb(dp[v], takeChild(dfs(w), e));
-		}
-		return dp[v] = fin(dp[v], v);
-	}
+  D dfs0(z v, z p, auto& g) {
+    A ca = e;
+    for (auto [c, w] : g[v]) if(c-p) {
+      ca = agg(ca, from_child(v, c, w, dfs0(c, v, g)));
+    }
+    return dp[v] = fin(v, ca);
+  }
+  void dfs1(z v, z p, auto& g) {
+    vector ps = {e};
+    for (auto [c, w] : g[v]) {
+      ps.push_back(from_child(v, c, w, dp[c]));
+    }
+    auto ss = ps;
+    exclusive_scan(ps.begin(), ps.end(), ps.begin(), e, agg);
+    exclusive_scan(ss.rbegin(),ss.rend(),ss.rbegin(),e, agg);
+    z i = 0;
+    for (auto [c, w] : g[v]) if(++i, c-p) {
+      dp[v] = fin(v, agg(ss[i], ps[i]));
+      dfs1(c, v, g);
+    }
+    dp[v] = fin(v, ss[0]);
+  }
 
-	vector<T> solve(int n, vector<pair<int, int>> edges) {
-		g.resize(n);
-		for (int i = 0; i < n-1; i++) {
-			g[edges[i].first].emplace_back(edges[i].second, 2*i);
-			g[edges[i].second].emplace_back(edges[i].first, 2*i+1);
-		}
-		pae.assign(n, -1);
-		dp.assign(n, E());
-		dfs(0);
-		vector<T> updp(n, E()), res(n, E());
-		for (int v : ord) {
-			vector<T> pref(sz(g[v])+1), suff(sz(g[v])+1);
-			if (v != 0) pref[0] = takeChild(updp[v], pae[v]);
-			for (int i = 0; i < sz(g[v]); i++){
-				auto [u, w] = g[v][i];
-				pref[i+1] = suff[i] = takeChild(dp[u], w);
-				pref[i+1] = comb(pref[i], pref[i+1]);
-			}
-			for (int i = sz(g[v])-1; i >= 0; i--) {
-				suff[i] = comb(suff[i], suff[i+1]);
-			}
-			for (int i = 0; i < sz(g[v]); i++) {
-				updp[g[v][i].first] = fin(comb(pref[i], suff[i+1]), v);
-			}
-			res[v] = fin(pref.back(), v);
-		}
-		return res;
-	}
+  auto solve(auto g) {
+    dp.resize(sz(g));
+    dfs0(0, 0, g);
+    dfs1(0, 0, g);
+    return dp;
+  }
 };

--- a/content/graph/reroot.cpp
+++ b/content/graph/reroot.cpp
@@ -1,51 +1,48 @@
-// output[r] = dp[r], where dp[v] :=
-//  fin(Sum_{child c of v, regarding root r} fromChild( dp[c] ))
+using W = ll; // edge weight type
+vector<vector<pair<int, W>>> adj;
 
-// To remove weights, remove every "w" and "W" and fix errors
 struct Reroot {
-  using D = /*todo*/; // dp value
-  using A = /*todo(often D)*/; //value from a vertex's child(ren)
-                               //(A,agg,e) commutative monoid
+	using T = ll; // dp type
 
-  A e = /*todo*/;
-  A fromChild(int v, int c, auto w, D dp_c) { /*todo*/ }
-  static A agg(A a, A b) { /*todo*/ }
-  D fin(int v, A chilsAgg) { /*todo*/ }
+	static constexpr T E = 0; // neutral element
+	T takeChild(int v, int c, W w, T x) {} // move child along edge
+	static T comb(T x, T y) {}
+	T fin(int v, T x) {} // add v to own dp value x
 
-  vector<D> dp;
+	vector<T> dp;
 
-  D dfs0(auto& g, int v, int from = -1) {
-    A ca = e;
-    for (auto [c, w] : g[v]) {
-      if (c == from) continue;
-      ca = agg(ca, fromChild(v, c, w, dfs0(c, v, g)));
-    }
-    return dp[v] = fin(v, ca);
-  }
+	T dfs0(int v, int from = -1) {
+		T val = E;
+		for (auto& [u, w] : adj[v]) {
+			if (u == from) continue;
+			val = comb(val, takeChild(v, u, w, dfs0(u, v)));
+		}
+		return dp[v] = fin(v, val);
+	}
 
-  void dfs1(auto& g, int v, int from = -1) {
-    vector ps = {e};
-    for (auto [c, w] : g[v]) {
-      ps.push_back(fromChild(v, c, w, dp[c]));
-    }
-    auto ss = ps;
-    exclusive_scan(be(ps), ps.begin(), e, agg);
-    exclusive_scan(ss.rbegin(), ss.rend(), ss.rbegin(), e, agg);
-    int i = 0;
-    for (auto [c, w] : g[v]) {
-      ++i;
-      if (c == from) continue;
-      dp[v] = fin(v, agg(ss[i], ps[i]));
-      dfs1(c, v, g);
-    }
-    dp[v] = fin(v, ss[0]);
-  }
+	void dfs1(int v, int from = -1) {
+		vector<T> pref = {E};
+		for (auto [u, w] : adj[v]) {
+			pref.push_back(takeChild(v, u, w, dp[u]));
+		}
+		auto suf = pref;
+		partial_sum(all(pref), pref.begin(), comb);
+		exclusive_scan(suf.rbegin(), suf.rend(),
+		               suf.rbegin(), E, comb);
 
-  template<typename W>
-  auto solve(vector<vector<pair<int, W>>> g) {
-    dp.resize(sz(g));
-    dfs0(g, 0);
-    dfs1(g, 0);
-    return dp;
-  }
+		for (int i = 0; i < sz(adj[v]); i++) {
+			auto [u, w] = adj[v][i];
+			if (u == from) continue;
+			dp[v] = fin(v, comb(pref[i], suf[i + 1]));
+			dfs1(u, v);
+		}
+		dp[v] = fin(v, suf[0]);
+	}
+
+	auto solve() {
+		dp.assign(sz(adj), E);
+		dfs0(0);
+		dfs1(0);
+		return dp;
+	}
 };

--- a/content/graph/reroot.cpp
+++ b/content/graph/reroot.cpp
@@ -1,47 +1,51 @@
-// input: undirected (un)weighted tree as
-//        adjacency list containing pair<neighbour,weight>s
-//        (To remove weights, remove every "w" and fix errors)
 // output[r] = dp[r], where dp[v] :=
-//  fin(Sum_{child c of v, regarding root r} from_child( dp[c] ))
+//  fin(Sum_{child c of v, regarding root r} fromChild( dp[c] ))
+
+// To remove weights, remove every "w" and "W" and fix errors
 struct Reroot {
-  using D = todo; // dp value
-  using A = todo (often D); // value from a vertex's child(ren)
+  using D = /todo/; // dp value
+  using A = /todo/ (often D); // value from a vertex's child(ren)
                             // (A,agg,e) commutative monoid
 
-  A e = todo;
-  A from_child(z v, z c, auto w, D dp_c) { todo }
-  static A agg(A a, A b) { todo }
-  D fin(z v, A chils_agg) { todo }
+  A e = /todo/;
+  A fromChild(int v, int c, auto w, D dp_c) { /todo/ }
+  static A agg(A a, A b) { /todo/ }
+  D fin(int v, A chilsAgg) { /todo/ }
 
   vector<D> dp;
 
-  D dfs0(z v, z p, auto& g) {
+  D dfs0(auto& g, int v, int from = -1) {
     A ca = e;
-    for (auto [c, w] : g[v]) if(c-p) {
-      ca = agg(ca, from_child(v, c, w, dfs0(c, v, g)));
+    for (auto [c, w] : g[v]) {
+      if (c == from) continue;
+      ca = agg(ca, fromChild(v, c, w, dfs0(c, v, g)));
     }
     return dp[v] = fin(v, ca);
   }
-  void dfs1(z v, z p, auto& g) {
+
+  void dfs1(auto& g, int v, int from = -1) {
     vector ps = {e};
     for (auto [c, w] : g[v]) {
-      ps.push_back(from_child(v, c, w, dp[c]));
+      ps.push_back(fromChild(v, c, w, dp[c]));
     }
     auto ss = ps;
     exclusive_scan(ps.begin(), ps.end(), ps.begin(), e, agg);
     exclusive_scan(ss.rbegin(),ss.rend(),ss.rbegin(),e, agg);
-    z i = 0;
-    for (auto [c, w] : g[v]) if(++i, c-p) {
+    int i = 0;
+    for (auto [c, w] : g[v]) {
+      ++i;
+      if (c == from) continue;
       dp[v] = fin(v, agg(ss[i], ps[i]));
       dfs1(c, v, g);
     }
     dp[v] = fin(v, ss[0]);
   }
 
-  auto solve(auto g) {
+  template<typename W>
+  auto solve(vector<vector<pair<int, W>>> g) {
     dp.resize(sz(g));
-    dfs0(0, 0, g);
-    dfs1(0, 0, g);
+    dfs0(g, 0);
+    dfs1(g, 0);
     return dp;
   }
 };

--- a/content/graph/reroot.cpp
+++ b/content/graph/reroot.cpp
@@ -4,44 +4,44 @@
 // output[r] = dp[r], where dp[v] :=
 //  fin(Sum_{child c of v, regarding root r} from_child( dp[c] ))
 struct Reroot {
-    using D = todo; // dp value
-    using A = todo (often D); // value from a vertex's child(ren)
-                              // (A,agg,e) commutative monoid
+  using D = todo; // dp value
+  using A = todo (often D); // value from a vertex's child(ren)
+                            // (A,agg,e) commutative monoid
 
-    A e = todo;
-    A from_child(z v, z c, auto w, D dp_c) { todo }
-    static A agg(A a, A b) { todo }
-    D fin(z v, A chils_agg) { todo }
+  A e = todo;
+  A from_child(z v, z c, auto w, D dp_c) { todo }
+  static A agg(A a, A b) { todo }
+  D fin(z v, A chils_agg) { todo }
 
-    vector<D> dp;
+  vector<D> dp;
 
-    D dfs0(z v, z p, auto& g) {
-        A ca = e;
-        for(auto [c, w] : g[v]) if(c-p) {
-            ca = agg(ca, from_child(v, c, w, dfs0(c, v, g)));
-        }
-        return dp[v] = fin(v, ca);
+  D dfs0(z v, z p, auto& g) {
+    A ca = e;
+    for (auto [c, w] : g[v]) if(c-p) {
+      ca = agg(ca, from_child(v, c, w, dfs0(c, v, g)));
     }
-    void dfs1(z v, z p, auto& g) {
-        vector ps = {e};
-        for(auto [c, w] : g[v]) {
-            ps.push_back(from_child(v, c, w, dp[c]));
-        }
-        auto ss = ps;
-        exclusive_scan(ps.begin(), ps.end(), ps.begin(), e, agg);
-        exclusive_scan(ss.rbegin(),ss.rend(),ss.rbegin(),e, agg);
-        z i = 0;
-        for(auto [c, w] : g[v]) if(++i, c-p) {
-            dp[v] = fin(v, agg(ss[i], ps[i]));
-            dfs1(c, v, g);
-        }
-        dp[v] = fin(v, s[0]);
+    return dp[v] = fin(v, ca);
+  }
+  void dfs1(z v, z p, auto& g) {
+    vector ps = {e};
+    for (auto [c, w] : g[v]) {
+      ps.push_back(from_child(v, c, w, dp[c]));
     }
+    auto ss = ps;
+    exclusive_scan(ps.begin(), ps.end(), ps.begin(), e, agg);
+    exclusive_scan(ss.rbegin(),ss.rend(),ss.rbegin(),e, agg);
+    z i = 0;
+    for (auto [c, w] : g[v]) if(++i, c-p) {
+      dp[v] = fin(v, agg(ss[i], ps[i]));
+      dfs1(c, v, g);
+    }
+    dp[v] = fin(v, s[0]);
+  }
 
-    auto solve(auto g) {
-        dp.resize(sz(g));
-        dfs0(0, 0, g);
-        dfs1(0, 0, g);
-        return dp;
-    }
+  auto solve(auto g) {
+    dp.resize(sz(g));
+    dfs0(0, 0, g);
+    dfs1(0, 0, g);
+    return dp;
+  }
 };

--- a/content/graph/reroot.cpp
+++ b/content/graph/reroot.cpp
@@ -13,7 +13,7 @@ struct Reroot {
 
 	T dfs0(int v, int from = -1) {
 		T val = E;
-		for (auto& [u, w] : adj[v]) {
+		for (auto [u, w] : adj[v]) {
 			if (u == from) continue;
 			val = comb(val, takeChild(v, u, w, dfs0(u, v)));
 		}

--- a/content/graph/reroot.cpp
+++ b/content/graph/reroot.cpp
@@ -4,7 +4,7 @@ vector<vector<pair<int, W>>> adj;
 struct Reroot {
 	using T = ll; // dp type
 
-	static constexpr T E = 0; // neutral element
+	T E = 0; // neutral element
 	T takeChild(int v, int c, W w, T x) {} // move child along edge
 	static T comb(T x, T y) {}
 	T fin(int v, T x) {} // add v to own dp value x


### PR DESCRIPTION
Explanation:
- dfs0 calculates dp values regarding root 0
- in dfs1:
  - before visiting v, dp[v] is correct regarding root 0  
  - when visiting child c of v, dp[v] is correct regarding root c  
  - after visiting v, dp[v] is correct regarding root v